### PR TITLE
Added setup.py file to allow use of ar10 class in other packages

### DIFF
--- a/ar10/CMakeLists.txt
+++ b/ar10/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(catkin REQUIRED COMPONENTS
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
 ## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
+catkin_python_setup()
 
 ################################################
 ## Declare ROS messages, services and actions ##

--- a/ar10/setup.py
+++ b/ar10/setup.py
@@ -1,0 +1,11 @@
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+
+setup_args = generate_distutils_setup(
+    packages=['ros_ar10_class'],
+    package_dir={'':'scripts'},
+    requires=['std_msgs', 'rospy', 'geometry_msgs']
+)
+
+setup(**setup_args)


### PR DESCRIPTION
This edit should allow easier use of the ar10 with other packages.

setup.py file lets you call the class in another package:

```python
from ros_ar10_class import ar10
```
